### PR TITLE
ignore prod env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env.production
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
https://rozwiazaniadlaniewidomych.atlassian.net/browse/PT-146

na serwerze brakowało pliku ze zmiennymi dla buildu produkcyjnego. zrobiłem go tam i dorzuciłem do gitignore 
.env.production

Produkcja jest przebudowana 